### PR TITLE
Updated links in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # OG-USA
 
-OG-USA is an overlapping-generations (OG) model of the economy of the United States (USA) that allows for dynamic general equilibrium analysis of federal tax policy. The model output focuses changes in macroeconomic aggregates (GDP, investment, consumption), wages, interest rates, and the stream of tax revenues over time. Careful documentation of the model--its output, and solution method--is available [here](https://github.com/open-source-economics/OG-USA/blob/master/docs/OGUSAdoc.pdf) and is regularly updated.
+OG-USA is an overlapping-generations (OG) model of the economy of the United States (USA) that allows for dynamic general equilibrium analysis of federal tax policy. The model output focuses changes in macroeconomic aggregates (GDP, investment, consumption), wages, interest rates, and the stream of tax revenues over time. Careful documentation of the model--its output, and solution method--is available [here](https://github.com/PSLmodels/OG-USA/blob/master/docs/OGUSAdoc.pdf) and is regularly updated.
 
 
 ## Disclaimer
@@ -8,11 +8,7 @@ OG-USA is an overlapping-generations (OG) model of the economy of the United Sta
 The model is currently under development. Users should be forewarned that the
 model components could change significantly. Therefore, there is NO GUARANTEE
 OF ACCURACY. THE CODE SHOULD NOT CURRENTLY BE USED FOR PUBLICATIONS, JOURNAL
-ARTICLES, OR RESEARCH PURPOSES. Essentially, you should assume the calculations
-are unreliable until we finish the code re-architecture and have checked the
-results against other existing implementations of the tax code. The package
-will have released versions, which will be checked against existing code prior
-to release. Stay tuned for an upcoming release!
+ARTICLES, OR RESEARCH PURPOSES. Essentially, you should assume the calculations are unreliable until we finish the code re-architecture and have checked the results against other existing implementations of the tax code. The package will have released versions, which will be checked against existing code prior to release. Stay tuned for an upcoming release!
 
 
 ## Using/contributing to OG-USA
@@ -47,4 +43,4 @@ If you run into errors running the example script, please open a new issue in th
 
 ## Citing OG-USA
 
-OG-USA (Version 0.5.7)[Source code], https://github.com/open-source-economics/OG-USA
+OG-USA (Version 0.5.7)[Source code], https://github.com/PSLmodels/OG-USA


### PR DESCRIPTION
@MaxGhenis . Thanks for catching this and submitting the PR. I think we want the documentation link to be the one in this PR that references the `PSLmodels/OG-USA` repo location. Your PR also made me remember to change the link at the bottom of the `README.md`.

If you merge this change of mine into your branch and if @jdebacker approves, we'll merge this fix into the OG-USA `README.md`.